### PR TITLE
Fix request logger not logging all key/value pairs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Request logger didn't log all key/value pairs.
 
 ## [0.6.3] - 2021-08-03
 ### Fixed

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -91,7 +91,7 @@ the Argo CloudOps service.
 * To run in debug mode set log level DEBUG before running
 
     ```
-    export ARGO_CLOUD_OPS_LOG_LEVEL=DEBUG
+    export ARGO_CLOUDOPS_LOG_LEVEL=DEBUG
     make ; make up
     ```
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -62,7 +62,7 @@ func (h *handler) healthCheck(w http.ResponseWriter, r *http.Request) {
 	// #nosec
 	response, err := http.Get(vaultEndpoint)
 	if err != nil {
-		level.Error(h.logger).Log("message", "received error connecting to vault", "error", err)
+		level.Error(l).Log("message", "received error connecting to vault", "error", err)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprintln(w, "Health check failed")
 		return
@@ -74,12 +74,12 @@ func (h *handler) healthCheck(w http.ResponseWriter, r *http.Request) {
 	defer response.Body.Close()
 	_, err = ioutil.ReadAll(response.Body)
 	if err != nil {
-		level.Warn(h.logger).Log("message", "unable to read vault body; continuing", "error", err)
+		level.Warn(l).Log("message", "unable to read vault body; continuing", "error", err)
 		// Continue on and handle the actual response code from Vault accordingly.
 	}
 
 	if response.StatusCode != 200 && response.StatusCode != 429 {
-		level.Error(h.logger).Log("message", fmt.Sprintf("received code %d which is not 200 (initialized, unsealed, and active) or 429 (unsealed and standby) when connecting to vault", response.StatusCode))
+		level.Error(l).Log("message", fmt.Sprintf("received code %d which is not 200 (initialized, unsealed, and active) or 429 (unsealed and standby) when connecting to vault", response.StatusCode))
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprintln(w, "Health check failed")
 		return
@@ -803,6 +803,9 @@ func generateEnvVariablesString(environmentVariables map[string]string) string {
 	return r
 }
 
-func (h handler) requestLogger(r *http.Request, fields ...string) log.Logger {
-	return log.With(h.logger, "txid", r.Header.Get(txIDHeader), fields)
+func (h handler) requestLogger(r *http.Request, fields ...interface{}) log.Logger {
+	return log.With(
+		h.logger,
+		append([]interface{}{"txid", r.Header.Get(txIDHeader)}, fields...)...,
+	)
 }


### PR DESCRIPTION
Before:
```sh
ts=2021-08-04T20:15:34.408972Z level=debug txid=11c15f2f-db86-43eb-a715-117ab517a78e message=executing
```

After:
```sh
ts=2021-08-04T20:45:24.138217Z level=debug txid=34f1833d-c2bf-4b84-8dd5-406263125383 op=health-check vault-endpoint=http://127.0.0.1:8200/v1/sys/health message=executing
```