### PR TITLE
Fix invalid json response when creating a project with invalid creds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * config.listFrameworks() are now sorted (helps avoid flaky tests).
 
 ### Fixed
-* Request logger didn't log all key/value pairs.
 * config.listFrameworks() was returning additional empty items.
+* Invalid json response when creating a project with invalid admin credentials.
+* Request logger didn't log all key/value pairs.
 * Vault token exchange logic for examples when there's a failure.
 
 ## [0.6.3] - 2021-08-03

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -466,7 +466,9 @@ func (h handler) createProject(w http.ResponseWriter, r *http.Request) {
 	a := credentials.NewAuthorization(ah)
 	if err := a.Validate(a.ValidateAuthorizedAdmin(h.env.AdminSecret)); err != nil {
 		h.errorResponse(w, "error unauthorized, invalid authorization header", http.StatusUnauthorized)
+		return
 	}
+
 	ctx := r.Context()
 
 	var capp requests.CreateProject

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -167,24 +167,25 @@ func (m mockCredentialsProvider) TargetExists(projectName, targetName string) (b
 }
 
 type test struct {
-	name    string
-	req     interface{}
-	want    int
-	body    string
-	asAdmin bool
-	url     string
-	method  string
+	name     string
+	req      interface{}
+	want     int
+	body     string
+	respFile string
+	asAdmin  bool
+	url      string
+	method   string
 }
 
 func TestCreateProject(t *testing.T) {
 	tests := []test{
 		{
-			name:    "fails to create project when not admin",
-			req:     loadCreateProjectRequest(t, "TestCreateProject/fails_to_create_project_when_not_admin.json"),
-			want:    http.StatusUnauthorized,
-			asAdmin: false,
-			url:     "/projects",
-			method:  "POST",
+			name:     "fails to create project when not admin",
+			req:      loadCreateProjectRequest(t, "TestCreateProject/fails_to_create_project_when_not_admin.json"),
+			want:     http.StatusUnauthorized,
+			respFile: "TestCreateProject/fails_to_create_project_when_not_admin_response.json",
+			url:      "/projects",
+			method:   "POST",
 		},
 		{
 			name:    "can create project",
@@ -726,6 +727,20 @@ func runTests(t *testing.T, tests []test) {
 				if tt.body != string(bodyBytes) {
 					t.Errorf("Unexpected body '%s', expected '%s'", bodyBytes, tt.body)
 				}
+			}
+
+			if tt.respFile != "" {
+				wantBody, err := loadFileBytes(tt.respFile)
+				if err != nil {
+					t.Fatalf("unable to read response file '%s', err: '%s'", tt.respFile, err)
+				}
+
+				body, err := io.ReadAll(resp.Body)
+				assert.Nil(t, err)
+
+				defer resp.Body.Close()
+
+				assert.JSONEq(t, string(wantBody), string(body))
 			}
 		})
 	}

--- a/service/testdata/TestCreateProject/fails_to_create_project_when_not_admin_response.json
+++ b/service/testdata/TestCreateProject/fails_to_create_project_when_not_admin_response.json
@@ -1,0 +1,3 @@
+{
+  "error_message": "error unauthorized, invalid authorization header"
+}


### PR DESCRIPTION
Prior to this change, it was returning:

```
{"error_message":"error unauthorized, invalid authorization header"}{"token":"vault::"}
```