### PR TITLE
Add codecov

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,24 @@ jobs:
           ${{ runner.os }}-go-
     - name: Run build
       run: make
+    - name: Generate code coverage artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage
+        path: coverage.out
+  coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Get code coverage artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: code-coverage
+      - name: Upload code coverage information to codecov.io
+        uses: codecov/codecov-action@v2
+        with:
+          files: coverage.out
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This successfully uploads the coverage report. The [report](https://codecov.io/gh/argoproj-labs/argo-cloudops/commit/0d16b4d78799782dd60b4318897656692fc34fb8/) currently is not processed by codecov as codecov does not have info for the parent commit (base of branch). Once this is merged in, it should create a report for master and future PRs should have coverage reported correctly.