### PR TITLE
Adding npx commands for testing

### DIFF
--- a/argo-cloudops.yaml
+++ b/argo-cloudops.yaml
@@ -8,6 +8,9 @@ commands:
   cdk:
     diff: "{{.EnvironmentVariables}} cdk bootstrap && {{.EnvironmentVariables}} cdk diff {{.ExecuteArguments}}"
     sync: "{{.EnvironmentVariables}} cdk bootstrap && {{.EnvironmentVariables}} cdk deploy {{.ExecuteArguments}}"
+    # testing the use of npx, will be removed once testing is completed
+    npxdiff: "echo 'using npx' && {{.EnvironmentVariables}} npx cdk diff {{.ExecuteArguments}}"
+    npxsync: "echo 'using npx' && {{.EnvironmentVariables}} npx cdk deploy {{.ExecuteArguments}}"
   terraform:
     diff: "{{.EnvironmentVariables}} terraform init {{.InitArguments}} && {{.EnvironmentVariables}} terraform plan {{.ExecuteArguments}}"
     sync: "{{.EnvironmentVariables}} terraform init {{.InitArguments}} && {{.EnvironmentVariables}} terraform apply {{.ExecuteArguments}}"


### PR DESCRIPTION
Adding `npx` commands for CDK operations to prevent breaking the service during testing.