### PR TITLE
feat(api): adding approved-list for container URIs

### DIFF
--- a/docs/users/envvars.md
+++ b/docs/users/envvars.md
@@ -2,22 +2,23 @@
 
 Argo CloudOps uses a number of environment variables for configuration. In addition to the table below, you can review the [start_local.sh](https://github.com/argoproj-labs/argo-cloudops/blob/main/scripts/start_local.sh) script for examples.
 
-| Name                                       | Description                                                                                                                                     |
-|--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| ARGO_CLOUDOPS_ADMIN_SECRET                 | Secret for the Argo CloudOps API                                                                                                                |
-| VAULT_ROLE                                 | Role for accessing Vault API                                                                                                                                 |
-| VAULT_SECRET                               | Secret for access Vault instance                                                                                                                |
-| VAULT_ADDR                                 | Endpoint for the Vault instance                                                                                                                 |
-| ARGO_ADDR                                  | Argo Endpoint                                                                                                                                   |
-| ARGO_CLOUDOPS_WORKFLOW_EXECUTION_NAMESPACE | Namespace to use to execute the deployments in Argo Workflows (Default: argo)                                                                   |
+| Name                                       | Description                                                                                                                                    |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| ARGO_CLOUDOPS_ADMIN_SECRET                 | Secret for the Argo CloudOps API                                                                                                               |
+| VAULT_ROLE                                 | Role for accessing Vault API                                                                                                                   |
+| VAULT_SECRET                               | Secret for access Vault instance                                                                                                               |
+| VAULT_ADDR                                 | Endpoint for the Vault instance                                                                                                                |
+| ARGO_ADDR                                  | Argo Endpoint                                                                                                                                  |
+| ARGO_CLOUDOPS_WORKFLOW_EXECUTION_NAMESPACE | Namespace to use to execute the deployments in Argo Workflows (Default: argo)                                                                  |
 | ARGO_CLOUDOPS_CONFIG                       | File that contains argo cloudops command configuration. [Example](https://github.com/argoproj-labs/argo-cloudops/blob/main/argo-cloudops.yaml) |
-| SSH_PEM_FILE                               | PEM file to use for GITHUB access authentication                                                                                                |
-| ARGO_CLOUDOPS_GIT_AUTH_METHOD              | A value of SSH or HTTPS depending on which authentication method prefered.                                                                      |
-| ARGO_CLOUDOPS_GIT_HTTPS_USER               | User name for GITHUB access authentication via HTTPS.                                                                                           |
-| ARGO_CLOUDOPS_GIT_HTTPS_PASS               | Password for GITHUB access authentication via HTTPS.                                                                                            |
-| ARGO_CLOUDOPS_DB_HOST                      | Database Host                                                                                                                                   |
-| ARGO_CLOUDOPS_DB_USER                      | Database User                                                                                                                                   |
-| ARGO_CLOUDOPS_DB_PASSWORD                  | Database Password                                                                                                                               |
-| ARGO_CLOUDOPS_DB_NAME                      | Database name                                                                                                                                   |
-| ARGO_CLOUDOPS_LOG_LEVEL                    | The configured log level for Argo CloudOps service (Default: Info)                                                                              |
-| ARGO_CLOUDOPS_PORT                         | Port which the Argo CloudOps service listens (Default: 8443)                                                                                    |
+| SSH_PEM_FILE                               | PEM file to use for GITHUB access authentication                                                                                               |
+| ARGO_CLOUDOPS_GIT_AUTH_METHOD              | A value of SSH or HTTPS depending on which authentication method prefered.                                                                     |
+| ARGO_CLOUDOPS_GIT_HTTPS_USER               | User name for GITHUB access authentication via HTTPS.                                                                                          |
+| ARGO_CLOUDOPS_GIT_HTTPS_PASS               | Password for GITHUB access authentication via HTTPS.                                                                                           |
+| ARGO_CLOUDOPS_DB_HOST                      | Database Host                                                                                                                                  |
+| ARGO_CLOUDOPS_DB_USER                      | Database User                                                                                                                                  |
+| ARGO_CLOUDOPS_DB_PASSWORD                  | Database Password                                                                                                                              |
+| ARGO_CLOUDOPS_DB_NAME                      | Database name                                                                                                                                  |
+| ARGO_CLOUDOPS_LOG_LEVEL                    | The configured log level for Argo CloudOps service (Default: Info)                                                                             |
+| ARGO_CLOUDOPS_PORT                         | Port which the Argo CloudOps service listens (Default: 8443)                                                                                   |
+| ARGO_CLOUDOPS_IMAGE_URIS                   | List of approved image URI patterns. See IsApprovedImageURI validation doc for examples                                                        |

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -73,6 +73,10 @@ func (req CreateWorkflow) validateParameters() error {
 		if !validations.IsValidImageURI(val) {
 			return errors.New("parameter pre_container_image_uri must be a valid container uri")
 		}
+
+		if !validations.IsApprovedImageURI(val) {
+			return errors.New("parameter pre_container_image_uri must be an approved image uri")
+		}
 	}
 
 	return nil

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -65,6 +65,10 @@ func (req CreateWorkflow) validateParameters() error {
 		return errors.New("parameter execute_container_image_uri must be a valid container uri")
 	}
 
+	if !validations.IsApprovedImageURI(val) {
+		return errors.New("parameter execute_container_image_uri must be an approved image uri")
+	}
+
 	if val, ok := req.Parameters["pre_container_image_uri"]; ok {
 		if !validations.IsValidImageURI(val) {
 			return errors.New("parameter pre_container_image_uri must be a valid container uri")

--- a/internal/validations/validations_test.go
+++ b/internal/validations/validations_test.go
@@ -139,6 +139,41 @@ func TestIsValidImageURI(t *testing.T) {
 	}
 }
 
+func TestIsApprovedImageURI(t *testing.T) {
+	tests := []struct {
+		name       string
+		testString string
+		want       bool
+		uris       []string
+	}{
+		{
+			name:       "default allow-all passes",
+			testString: "argocloudops/argo-cloudops-cdk:1.87.1",
+			want:       true,
+		},
+		{
+			name:       "matched image from config passes",
+			testString: "argocloudops/match:1.87.1",
+			want:       true,
+			uris:       []string{"argocloudops/match:1.87.1"},
+		},
+		{
+			name:       "rejects non-approved image",
+			testString: "argocloudops/nomatch:1.87.1",
+			want:       false,
+			uris:       []string{"argocloudops/match:1.87.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetImageURIs(tt.uris)
+
+			assert.Equal(t, tt.want, IsApprovedImageURI(tt.testString))
+		})
+	}
+}
+
 func TestIsValidARN(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/validations/validations_test.go
+++ b/internal/validations/validations_test.go
@@ -152,7 +152,7 @@ func TestIsApprovedImageURI(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "matched image from config passes",
+			name:       "direct matched image from config passes",
 			testString: "argocloudops/match:1.87.1",
 			want:       true,
 			uris:       []string{"argocloudops/match:1.87.1"},
@@ -162,6 +162,18 @@ func TestIsApprovedImageURI(t *testing.T) {
 			testString: "argocloudops/nomatch:1.87.1",
 			want:       false,
 			uris:       []string{"argocloudops/match:1.87.1"},
+		},
+		{
+			name:       "matches globbing on tag",
+			testString: "argocloudops/match:1.87.1",
+			want:       true,
+			uris:       []string{"argocloudops/match:*"},
+		},
+		{
+			name:       "matches globbing on any image within a registry",
+			testString: "docker.myco.com/argocloudops/match:1.87.1",
+			want:       true,
+			uris:       []string{"docker.myco.com/*/*"},
 		},
 	}
 

--- a/service/config.go
+++ b/service/config.go
@@ -9,6 +9,8 @@ import (
 	"text/template"
 
 	"gopkg.in/yaml.v2"
+
+	"github.com/argoproj-labs/argo-cloudops/internal/validations"
 )
 
 // CommandVariables respresents the config items for a command.
@@ -36,6 +38,8 @@ func loadConfig(configFilePath string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	validations.SetImageURIs(config.ImageURIs)
 
 	return &config, nil
 }

--- a/service/config.go
+++ b/service/config.go
@@ -9,8 +9,6 @@ import (
 	"text/template"
 
 	"gopkg.in/yaml.v2"
-
-	"github.com/argoproj-labs/argo-cloudops/internal/validations"
 )
 
 // CommandVariables respresents the config items for a command.
@@ -22,9 +20,8 @@ type CommandVariables struct {
 
 // Config represents the configuration.
 type Config struct {
-	Version   string
-	Commands  map[string]map[string]string `yaml:"commands"`
-	ImageURIs []string                     `yaml:"image_uris"`
+	Version  string
+	Commands map[string]map[string]string `yaml:"commands"`
 }
 
 func loadConfig(configFilePath string) (*Config, error) {
@@ -38,8 +35,6 @@ func loadConfig(configFilePath string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	validations.SetImageURIs(config.ImageURIs)
 
 	return &config, nil
 }

--- a/service/config.go
+++ b/service/config.go
@@ -20,8 +20,9 @@ type CommandVariables struct {
 
 // Config represents the configuration.
 type Config struct {
-	Version  string
-	Commands map[string]map[string]string `yaml:"commands"`
+	Version   string
+	Commands  map[string]map[string]string `yaml:"commands"`
+	ImageURIs []string                     `yaml:"image_uris"`
 }
 
 func loadConfig(configFilePath string) (*Config, error) {

--- a/service/internal/env/env.go
+++ b/service/internal/env/env.go
@@ -10,23 +10,24 @@ import (
 const appPrefix = "ARGO_CLOUDOPS"
 
 type Vars struct {
-	AdminSecret    string `split_words:"true" required:"true"`
-	VaultRole      string `envconfig:"VAULT_ROLE" required:"true"`
-	VaultSecret    string `envconfig:"VAULT_SECRET" required:"true"`
-	VaultAddress   string `envconfig:"VAULT_ADDR" required:"true"`
-	ArgoAddress    string `envconfig:"ARGO_ADDR" required:"true"`
-	ArgoNamespace  string `envconfig:"WORKFLOW_EXECUTION_NAMESPACE" default:"argo"`
-	ConfigFilePath string `envconfig:"CONFIG" default:"argo-cloudops.yaml"`
-	SSHPEMFile     string `envconfig:"SSH_PEM_FILE"`
-	GitAuthMethod  string `split_words:"true" required:"true"`
-	GitHTTPSUser   string `envconfig:"GIT_HTTPS_USER"`
-	GitHTTPSPass   string `envconfig:"GIT_HTTPS_PASS"`
-	LogLevel       string `split_words:"true"`
-	Port           int    `default:"8443"`
-	DBHost         string `split_words:"true" required:"true"`
-	DBUser         string `split_words:"true" required:"true"`
-	DBPassword     string `split_words:"true" required:"true"`
-	DBName         string `split_words:"true" required:"true"`
+	AdminSecret    string   `split_words:"true" required:"true"`
+	VaultRole      string   `envconfig:"VAULT_ROLE" required:"true"`
+	VaultSecret    string   `envconfig:"VAULT_SECRET" required:"true"`
+	VaultAddress   string   `envconfig:"VAULT_ADDR" required:"true"`
+	ArgoAddress    string   `envconfig:"ARGO_ADDR" required:"true"`
+	ArgoNamespace  string   `envconfig:"WORKFLOW_EXECUTION_NAMESPACE" default:"argo"`
+	ConfigFilePath string   `envconfig:"CONFIG" default:"argo-cloudops.yaml"`
+	SSHPEMFile     string   `envconfig:"SSH_PEM_FILE"`
+	GitAuthMethod  string   `split_words:"true" required:"true"`
+	GitHTTPSUser   string   `envconfig:"GIT_HTTPS_USER"`
+	GitHTTPSPass   string   `envconfig:"GIT_HTTPS_PASS"`
+	LogLevel       string   `split_words:"true"`
+	Port           int      `default:"8443"`
+	DBHost         string   `split_words:"true" required:"true"`
+	DBUser         string   `split_words:"true" required:"true"`
+	DBPassword     string   `split_words:"true" required:"true"`
+	DBName         string   `split_words:"true" required:"true"`
+	ImageURIs      []string `envconfig:"IMAGE_URIS"`
 }
 
 var (

--- a/service/main.go
+++ b/service/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/argoproj-labs/argo-cloudops/internal/validations"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/credentials"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/db"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/env"
@@ -45,6 +46,9 @@ func main() {
 		panic(fmt.Sprintf("Unable to load config %s", err))
 	}
 	level.Info(logger).Log("message", fmt.Sprintf("loading config '%s' completed", env.ConfigFilePath))
+
+	// temp, will rm after config restructure
+	validations.SetImageURIs(env.ImageURIs)
 
 	// The Argo context is needed for any Argo client method calls or else, nil errors.
 	argoCtx, argoClient := client.NewAPIClient()

--- a/service/main.go
+++ b/service/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/argoproj-labs/argo-cloudops/internal/validations"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/credentials"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/db"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/env"
@@ -46,7 +45,6 @@ func main() {
 		panic(fmt.Sprintf("Unable to load config %s", err))
 	}
 	level.Info(logger).Log("message", fmt.Sprintf("loading config '%s' completed", env.ConfigFilePath))
-	validations.SetImageURIs(config.ImageURIs)
 
 	// The Argo context is needed for any Argo client method calls or else, nil errors.
 	argoCtx, argoClient := client.NewAPIClient()

--- a/service/main.go
+++ b/service/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/argoproj-labs/argo-cloudops/internal/validations"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/credentials"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/db"
 	"github.com/argoproj-labs/argo-cloudops/service/internal/env"
@@ -45,6 +46,7 @@ func main() {
 		panic(fmt.Sprintf("Unable to load config %s", err))
 	}
 	level.Info(logger).Log("message", fmt.Sprintf("loading config '%s' completed", env.ConfigFilePath))
+	validations.SetImageURIs(config.ImageURIs)
 
 	// The Argo context is needed for any Argo client method calls or else, nil errors.
 	argoCtx, argoClient := client.NewAPIClient()


### PR DESCRIPTION
This is not a final PR, more of a quick hack / draft for discussion. I didn't cleanly think through naming etc, so poke away.

General concept here (and the same could be applied to git domains) is to enable some enterprise security controls via config. Definitely ran headfirst into the config structure, and specifically the way it (doesn't) flow through. This is a more surgical approach then unwinding some of those bigger issues or moving to a validation struct. Appreciate thoughts on the approach.