### PR TITLE
fix: corrected bug on default allow-all on approved image uris

### DIFF
--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -10,18 +10,12 @@ import (
 )
 
 var (
-	defaultAllowAll = []string{"**/*"}
-	imageURIs       = defaultAllowAll
+	imageURIs []string
 )
 
 // SetImageURIs restricts the approved container URIs to the provided set. To reset to a default allow-all state,
 // provide an empty list.
 func SetImageURIs(uris []string) {
-	if len(uris) == 0 {
-		imageURIs = defaultAllowAll
-		return
-	}
-
 	imageURIs = uris
 }
 
@@ -84,6 +78,11 @@ func IsValidImageURI(imageURI string) bool {
 // - Direct image, any tag: docker.myco.com/argocloudops/cdk:*
 // - Any image within a specific registry: docker.myco.com/*/*
 func IsApprovedImageURI(imageURI string) bool {
+	// default to allow all if no restrictions set
+	if len(imageURIs) == 0 {
+		return true
+	}
+
 	for _, pattern := range imageURIs {
 		if ok, _ := filepath.Match(pattern, imageURI); ok {
 			return true

--- a/internal/validations/validations_test.go
+++ b/internal/validations/validations_test.go
@@ -152,6 +152,12 @@ func TestIsApprovedImageURI(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "default allow-all passes with multi-separator",
+			testString: "docker.myco.com/slash1/argo-cloudops/slash2/argo-cloudops-cdk:latest",
+			want:       true,
+			uris:       []string{},
+		},
+		{
 			name:       "direct matched image from config passes",
 			testString: "argocloudops/match:1.87.1",
 			want:       true,


### PR DESCRIPTION
Stdlib filepath does not support the ** spec, causing the default allow
all to fail on multi-separator URIs.