### PR TITLE
feat: adding exec command, remove type override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Add `exec` type/command 
+
 ## [0.9.0] - 2021-12-14
 ### Added
 * Approve list for pre and execute image URIs.

--- a/argo-cloudops.yaml
+++ b/argo-cloudops.yaml
@@ -8,6 +8,7 @@ commands:
   cdk:
     diff: "{{.EnvironmentVariables}} cdk bootstrap && {{.EnvironmentVariables}} cdk diff {{.ExecuteArguments}}"
     sync: "{{.EnvironmentVariables}} cdk bootstrap && {{.EnvironmentVariables}} cdk deploy {{.ExecuteArguments}}"
+    exec: "{{.EnvironmentVariables}} npx cdk {{.Type}} {{.ExecuteArguments}}"
   terraform:
     diff: "{{.EnvironmentVariables}} terraform init {{.InitArguments}} && {{.EnvironmentVariables}} terraform plan {{.ExecuteArguments}}"
     sync: "{{.EnvironmentVariables}} terraform init {{.InitArguments}} && {{.EnvironmentVariables}} terraform apply {{.ExecuteArguments}}"

--- a/argo-cloudops.yaml
+++ b/argo-cloudops.yaml
@@ -8,7 +8,6 @@ commands:
   cdk:
     diff: "{{.EnvironmentVariables}} cdk bootstrap && {{.EnvironmentVariables}} cdk diff {{.ExecuteArguments}}"
     sync: "{{.EnvironmentVariables}} cdk bootstrap && {{.EnvironmentVariables}} cdk deploy {{.ExecuteArguments}}"
-    exec: "{{.EnvironmentVariables}} npx cdk {{.Type}} {{.ExecuteArguments}}"
   terraform:
     diff: "{{.EnvironmentVariables}} terraform init {{.InitArguments}} && {{.EnvironmentVariables}} terraform plan {{.ExecuteArguments}}"
     sync: "{{.EnvironmentVariables}} terraform init {{.InitArguments}} && {{.EnvironmentVariables}} terraform apply {{.ExecuteArguments}}"

--- a/cli/cmd/exec.go
+++ b/cli/cmd/exec.go
@@ -1,0 +1,52 @@
+//go:build !test
+// +build !test
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argoproj-labs/argo-cloudops/cli/internal/api"
+
+	"github.com/spf13/cobra"
+)
+
+// execCmd represents the exec command
+var execCmd = &cobra.Command{
+	Use:   "exec",
+	Short: "Executes an operation on a project target using a manifest in git",
+	Long:  "Executes an operation on a project target using a manifest in git",
+	Run: func(cmd *cobra.Command, args []string) {
+		token, err := argoCloudOpsUserToken()
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		apiCl := api.NewClient(argoCloudOpsServiceAddr(), token)
+
+		resp, err := apiCl.Exec(context.Background(), api.TargetOperationInput{Path: gitPath, ProjectName: projectName, SHA: gitSHA, TargetName: targetName})
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		// Our current contract is to output only the name.
+		fmt.Print(resp.WorkflowName)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(execCmd)
+
+	// TODO these should be '-' separated.
+	execCmd.Flags().StringVarP(&gitPath, "path", "p", "", "Path to manifest within git repository")
+	execCmd.Flags().StringVarP(&gitSHA, "sha", "s", "", "Commit sha to use when creating workflow through git")
+	execCmd.Flags().StringVarP(&projectName, "project_name", "n", "", "Name of project")
+	// TODO inconsistent
+	execCmd.Flags().StringVarP(&targetName, "target", "t", "", "Name of target")
+
+	execCmd.MarkFlagRequired("path")
+	execCmd.MarkFlagRequired("sha")
+	execCmd.MarkFlagRequired("project_name")
+	execCmd.MarkFlagRequired("target_name")
+}

--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -19,6 +19,7 @@ import (
 const (
 	diff                  = "diff"
 	defaultLocalSecureURI = "https://localhost:8443"
+	exec                  = "exec"
 	sync                  = "sync"
 )
 
@@ -169,6 +170,16 @@ func (c *Client) Diff(ctx context.Context, input TargetOperationInput) (response
 	}
 
 	return responses.Diff(output), nil
+}
+
+// Exec submits an "exec" for the provided project target.
+func (c *Client) Exec(ctx context.Context, input TargetOperationInput) (responses.Exec, error) {
+	output, err := c.targetOperation(ctx, input, exec)
+	if err != nil {
+		return responses.Exec{}, err
+	}
+
+	return responses.Exec(output), nil
 }
 
 // ExecuteWorkflow submits a workflow execution request.

--- a/cli/internal/api/api_test.go
+++ b/cli/internal/api/api_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	authToken = "secret1234"
+	authToken          = "secret1234"
+	operationsEndpoint = "/projects/project1/targets/target1/operations"
 )
 
 func TestGetLogs(t *testing.T) {
@@ -474,7 +475,7 @@ func TestDiff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			wantURL := "/projects/project1/targets/target1/operations"
+			wantURL := operationsEndpoint
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != wantURL {
@@ -715,7 +716,7 @@ func TestSync(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wantURL := "/projects/project1/targets/target1/operations"
+			wantURL := operationsEndpoint
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != wantURL {
@@ -836,7 +837,7 @@ func TestExec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wantURL := "/projects/project1/targets/target1/operations"
+			wantURL := operationsEndpoint
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != wantURL {

--- a/cli/internal/api/api_test.go
+++ b/cli/internal/api/api_test.go
@@ -779,6 +779,127 @@ func TestSync(t *testing.T) {
 	}
 }
 
+func TestExec(t *testing.T) {
+	tests := []struct {
+		name                  string
+		apiRespBody           []byte
+		apiRespStatusCode     int
+		endpoint              string          // Used to create new request error.
+		mockHTTPClient        *mockHTTPClient // Only used when needed.
+		writeBadContentLength bool            // Used to create response body error.
+		want                  responses.Exec
+		wantAPIReqBody        []byte
+		wantErr               error
+	}{
+		{
+			name:              "good",
+			apiRespBody:       readFile(t, "exec_response_good.json"),
+			apiRespStatusCode: http.StatusOK,
+			want: responses.Exec{
+				WorkflowName: "workflow1",
+			},
+			wantAPIReqBody: readFile(t, "exec_request_good.json"),
+		},
+		{
+			name:              "error non-200 response",
+			apiRespBody:       []byte("boom"),
+			apiRespStatusCode: http.StatusInternalServerError,
+			wantAPIReqBody:    readFile(t, "exec_request_good.json"),
+			wantErr:           fmt.Errorf("received unexpected status code: 500, body: boom"),
+		},
+		{
+			name:              "error non-json response",
+			apiRespBody:       []byte("boom"),
+			apiRespStatusCode: 200,
+			wantAPIReqBody:    readFile(t, "exec_request_good.json"),
+			wantErr:           fmt.Errorf("unable to parse response: invalid character 'b' looking for beginning of value"),
+		},
+		{
+			name:     "error creating http request",
+			endpoint: string('\f'),
+			wantErr:  fmt.Errorf(`unable to create api request: parse "\f/projects/project1/targets/target1/operations": net/url: invalid control character in URL`),
+		},
+		{
+			name:           "error making http request",
+			mockHTTPClient: &mockHTTPClient{errDo: fmt.Errorf("boom")},
+			wantErr:        fmt.Errorf("unable to make api call: boom"),
+		},
+		{
+			name:                  "error reading body",
+			apiRespBody:           nil,
+			apiRespStatusCode:     http.StatusOK,
+			writeBadContentLength: true,
+			wantAPIReqBody:        readFile(t, "exec_request_good.json"),
+			wantErr:               fmt.Errorf("error reading response body. status code: %d, error: unexpected EOF", http.StatusOK),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantURL := "/projects/project1/targets/target1/operations"
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != wantURL {
+					http.NotFound(w, r)
+				}
+
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+
+				if tt.writeBadContentLength {
+					w.Header().Set("Content-Length", "1")
+				}
+
+				// Make sure the request we received is what we want
+				body, err := io.ReadAll(r.Body)
+				r.Body.Close()
+
+				assert.Nil(t, err, "unable to read request body")
+
+				assert.JSONEq(t, string(body), string(tt.wantAPIReqBody))
+				assert.Equal(t, r.Header.Get("Authorization"), authToken)
+
+				w.WriteHeader(tt.apiRespStatusCode)
+				fmt.Fprint(w, string(tt.apiRespBody))
+			}))
+			defer server.Close()
+
+			client := Client{
+				authToken:  authToken,
+				endpoint:   server.URL,
+				httpClient: &http.Client{},
+			}
+
+			if tt.endpoint != "" {
+				client.endpoint = tt.endpoint
+			}
+
+			if tt.mockHTTPClient != nil {
+				client.httpClient = tt.mockHTTPClient
+			}
+
+			got, err := client.Exec(
+				context.Background(),
+				TargetOperationInput{
+					"./prod/target1.yaml",
+					"project1",
+					"7fa96067f580a20c3908f5b872377181091ffaec",
+					"target1",
+				},
+			)
+
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, got, tt.want)
+			}
+		})
+	}
+}
+
 type mockHTTPClient struct {
 	errDo error
 }

--- a/cli/internal/api/testdata/exec_request_good.json
+++ b/cli/internal/api/testdata/exec_request_good.json
@@ -1,0 +1,5 @@
+{
+  "path": "./prod/target1.yaml",
+  "sha": "7fa96067f580a20c3908f5b872377181091ffaec",
+  "type": "exec"
+}

--- a/cli/internal/api/testdata/exec_response_good.json
+++ b/cli/internal/api/testdata/exec_response_good.json
@@ -1,0 +1,3 @@
+{
+  "workflow_name": "workflow1"
+}

--- a/docs/cli/argo-cloudops.md
+++ b/docs/cli/argo-cloudops.md
@@ -12,6 +12,7 @@ argo-cloudops [command]
 Available Commands:
   completion  generate the autocompletion script for the specified shell
   diff        Diff a project target using a manifest in git
+  exec        Executes an operation on a project target using a manifest in git
   get         Gets status of workflow
   help        Help about any command
   list        List workflow executions for a given project and target

--- a/docs/cli/argo-cloudops_exec.md
+++ b/docs/cli/argo-cloudops_exec.md
@@ -9,7 +9,7 @@ Executes an operation on a project target using a manifest in git
 ### Flags
 
 ```
-  -h, --help                  help for sync
+  -h, --help                  help for exec
   -p, --path string           Path to manifest within git repository
   -n, --project_name string   Name of project
   -s, --sha string            Commit sha to use when creating workflow through git

--- a/docs/cli/argo-cloudops_exec.md
+++ b/docs/cli/argo-cloudops_exec.md
@@ -1,0 +1,17 @@
+## argo-cloudops exec
+
+Executes an operation on a project target using a manifest in git
+
+```
+  argo-cloudops exec [flags]
+```
+
+### Flags
+
+```
+  -h, --help                  help for sync
+  -p, --path string           Path to manifest within git repository
+  -n, --project_name string   Name of project
+  -s, --sha string            Commit sha to use when creating workflow through git
+  -t, --target string         Name of target
+```

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -172,8 +172,7 @@ Request Body
 ```json
 {
   "sha": "1234abdc5678efgh9012ijkl3456mnop7890qrst",
-  "path": "path/to/manifest.yaml",
-  "type": "sync"
+  "path": "path/to/manifest.yaml"
 }
 ```
 

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -101,9 +101,6 @@ func (req CreateWorkflow) validateArguments() error {
 type CreateGitWorkflow struct {
 	CommitHash string `json:"sha" valid:"required~sha is required,alphanum~sha must be alphanumeric"`
 	Path       string `json:"path" valid:"required~path is required"`
-	// We don't validate the specific type as it's dynamic and can only be done
-	// server side.
-	Type string `json:"type" valid:"required~type is required"`
 }
 
 // Validate validates CreateGitWorkflow.

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -392,14 +392,12 @@ func TestCreateGitWorkflowValidate(t *testing.T) {
 			req: CreateGitWorkflow{
 				CommitHash: "8458fd753f9fde51882414564c20df6d4c34a90e",
 				Path:       "./manifest.yaml",
-				Type:       "diff",
 			},
 		},
 		{
 			name: "missing commit hash",
 			req: CreateGitWorkflow{
 				Path: "./manifest.yaml",
-				Type: "diff",
 			},
 			wantErr: errors.New("sha is required"),
 		},
@@ -408,7 +406,6 @@ func TestCreateGitWorkflowValidate(t *testing.T) {
 			req: CreateGitWorkflow{
 				CommitHash: "8--",
 				Path:       "./manifest.yaml",
-				Type:       "diff",
 			},
 			wantErr: errors.New("sha must be alphanumeric"),
 		},
@@ -416,17 +413,8 @@ func TestCreateGitWorkflowValidate(t *testing.T) {
 			name: "missing path",
 			req: CreateGitWorkflow{
 				CommitHash: "8458fd753f9fde51882414564c20df6d4c34a90e",
-				Type:       "diff",
 			},
 			wantErr: errors.New("path is required"),
-		},
-		{
-			name: "missing type",
-			req: CreateGitWorkflow{
-				CommitHash: "8458fd753f9fde51882414564c20df6d4c34a90e",
-				Path:       "./manifest.yaml",
-			},
-			wantErr: errors.New("type is required"),
 		},
 	}
 

--- a/internal/responses/responses.go
+++ b/internal/responses/responses.go
@@ -3,6 +3,9 @@ package responses
 // Diff represents the responses for Diff.
 type Diff TargetOperation
 
+// Exec represents the responses for Exec.
+type Exec TargetOperation
+
 // ExecuteWorkflow represents the responses for ExecuteWorkflow.
 type ExecuteWorkflow struct {
 	WorkflowName string `json:"workflow_name"`

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -202,7 +202,6 @@ func (h handler) createWorkflowFromGit(w http.ResponseWriter, r *http.Request) {
 	log.With(l, "project", cwr.ProjectName, "target", cwr.TargetName, "framework", cwr.Framework, "type", cwr.Type, "workflow-template", cwr.WorkflowTemplateName)
 
 	level.Debug(l).Log("message", "creating workflow")
-	cwr.Type = cgwr.Type
 	h.createWorkflowFromRequest(ctx, w, r, a, cwr, l)
 }
 


### PR DESCRIPTION
resolves #248 

`exec` will use `type` specified in the manifest instead of using the type passed in via the CLI. Leaving `sync` and `diff` CLI flows as is for now to avoid breaking changes. There should be some work in the future to go back and remove both of those flows.